### PR TITLE
Fix mobile page overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,8 @@
 
 html {
     scroll-behavior: smooth;
+    max-width: 100%;
+    overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
Add global `max-width: 100%` and `overflow-x: hidden` to `html` to fix horizontal overflow on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-603af6b0-b0f3-4eff-9a80-262b7fbf7733">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-603af6b0-b0f3-4eff-9a80-262b7fbf7733">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

